### PR TITLE
Fix pytorch_lightning error in sd_hijack_ddpm_v1.py

### DIFF
--- a/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
+++ b/extensions-builtin/LDSR/sd_hijack_ddpm_v1.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from functools import partial
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config
 from ldm.modules.ema import LitEma


### PR DESCRIPTION
File: stable-diffusion\ldm\models\diffusion\DDPM.py
Line: 19ish

change:

from pytorch_lightning.utilities.distributed import rank_zero_only_

to:

from pytorch_lightning.utilities.rank_zero import rank_zero_only

This will fix the error "ModuleNotFoundError: No module named 'pytorch_lightning.utilities.distributed"

## Description

* a simple description of what you're trying to accomplish
* a summary of changes in code
* which issues it fixes, if any

## Screenshots/videos:


## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
